### PR TITLE
With hygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,12 @@
 ## Using Hygen
 
 Make this your own (call it 'amazing'):
+    $ HYGEN_OVERWRITE=1 hygen template init amazing
 
-    $ hygen template init amazing
-    ✔      exists: go.mod. Overwrite? (y/N):  (y/N) · true
-       added: go.mod
-    ✔      exists: main.go. Overwrite? (y/N):  (y/N) · true
+    Loaded templates: _templates
+        added: go.mod
         added: main.go
-    ✔      exists: README.md. Overwrite? (y/N):  (y/N) · true
         added: README.md
-    ✔      exists: cmd/root.go. Overwrite? (y/N):  (y/N) · true
         added: cmd/root.go
 
 Add commands:

--- a/_templates/template/init/README.md.t
+++ b/_templates/template/init/README.md.t
@@ -1,4 +1,8 @@
-# Welcome to go-template
+---
+to: README.md
+---
+
+# Welcome to <%= name %>
 
 ## Using Hygen
 

--- a/_templates/template/init/go.mod.t
+++ b/_templates/template/init/go.mod.t
@@ -1,0 +1,9 @@
+---
+to: go.mod
+---
+
+module github.com/rantav/<%= name %>
+
+go 1.12
+
+require github.com/spf13/cobra v0.0.5

--- a/_templates/template/init/main.go.t
+++ b/_templates/template/init/main.go.t
@@ -1,0 +1,13 @@
+---
+to: main.go
+---
+
+package main
+
+import (
+	"github.com/rantav/<%= name %>/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/_templates/template/init/root.go.t
+++ b/_templates/template/init/root.go.t
@@ -1,0 +1,21 @@
+---
+to: cmd/root.go
+---
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "<%= name %>",
+	Short: "A <%= name %> project",
+	Long:  `The long description`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Do Stuff Here
+	},
+}

--- a/_templates/template/new-cmd/cmd.go.t
+++ b/_templates/template/new-cmd/cmd.go.t
@@ -1,0 +1,39 @@
+---
+to: cmd/<%= name %>.go
+---
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// serveCmd represents the serve command
+var serveCmd = &cobra.Command{
+	Use:   "<%= name %>",
+	Short: "<%= desc %>",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("serve called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(serveCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// serveCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}


### PR DESCRIPTION
ergonomics:

```
hygen template [cmd] [name]
```

but it can be:

```
hygen new [cmd] [name]
```

or 

```
hygen backend-services [cmd] [name]
```

and so on. just play w/folder structure under `_templates`. folder structure will directly reflect command structure.
